### PR TITLE
Update versions.tf

### DIFF
--- a/nginx/versions.tf
+++ b/nginx/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     docker = {
       source = "kreuzwerker/docker"
-      version = "~> 2.16.0"
+      version = "~> 2.22.0"
     }
   }
 }


### PR DESCRIPTION
updated docker version to 2.22.0, was 2.16.0 (no longer available).